### PR TITLE
More main-hero Resolution Specs Adjustment

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -37,7 +37,7 @@
     'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
 }
 
-@media screen and (max-width: 1093px) {
+@media screen and (max-width: 1208px) {
     .hero-container > h1 {
         font-size: 80px;
         margin-top: -40px;


### PR DESCRIPTION
What was done?
Refined the title resolution specs for the main hero section.

Why was the change done?
With previous adjustments, the title had been made to overflow slightly at certain resolution specs.

What file(s) was changed?
The HeroSection.css file was modified to include refined alt text.

Test conducted?
It was tested locally and confirmed that the title does not overflow anymore.