### PR TITLE
Footer link now opens in new tab

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -4,7 +4,7 @@ import './Footer.css';
 function Footer() {
   return (
     <div className='footer-container'>
-      <p>*This project is funded by the National Science Foundation under award <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2201536&HistoricalAwards=false">2201536</a></p>
+      <p>*This project is funded by the National Science Foundation under award <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2201536&HistoricalAwards=false" target="_blank" rel="noopener noreferrer">2201536</a></p>
     </div>
   );
 }


### PR DESCRIPTION
What was done?
Adjusted the footer link to open in a new tab.

Why was the change done?
To enhance the user experience.

What file(s) was changed?
The Footer.js files was modified to have no link attributes.

Test conducted?
It was tested locally and confirmed that the Footer.js now displays in a new tab.