### PR TITLE
Removed unnecessary base css

### DIFF
--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,4 +1,3 @@
-import '../../App.css';
 import HeroSection from '../HeroSection';
 import MainSection from '../MainSection';
 

--- a/src/components/pages/Publications.js
+++ b/src/components/pages/Publications.js
@@ -1,4 +1,3 @@
-import '../../App.css';
 import PublicationsHero from '../PublicationsHero';
 import PublicationsMain from '../PublicationsMain';
 

--- a/src/components/pages/Team.js
+++ b/src/components/pages/Team.js
@@ -1,4 +1,3 @@
-import '../../App.css';
 import TeamHero from '../TeamHero';
 
 function Team() {


### PR DESCRIPTION
What was done?
Removed base css imports from all pages.

Why was the change done?
This base css was overridden by specified file css anyways in each case, so it is redundant.

What file(s) was changed?
The Home.js, Publications.js, and Team.js files were modified to exclude this base css import.

Test conducted?
It was tested locally and confirmed that the various pages still display properly.